### PR TITLE
feat: Ansible is setup along with k3s installation

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory.yaml
+interpreter_python = /usr/bin/python3
+roles_path = roles

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,0 +1,4 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,4 @@
+- name: Ansible playbook
+  hosts: localhost
+  roles:
+    - k3s

--- a/ansible/roles/k3s/tasks/main.yml
+++ b/ansible/roles/k3s/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: Check if K3s binary exists
+  ansible.builtin.stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary_check
+
+- name: Ensure K3s is installed
+  when: not k3s_binary_check.stat.exists
+  block:
+    - name: Download the K3s installation script
+      ansible.builtin.get_url:
+        url: https://get.k3s.io
+        dest: /tmp/install_k3s.sh
+        mode: "0755"
+
+    - name: Install K3s
+      ansible.builtin.shell: /tmp/install_k3s.sh
+      args:
+        executable: /bin/bash
+      become: true
+      changed_when: false
+
+    - name: Verify K3s installation
+      ansible.builtin.command: k3s --version
+      register: k3s_verify
+      changed_when: false
+      failed_when: k3s_verify.rc != 0
+
+    - name: Remove the K3s installation script
+      ansible.builtin.file:
+        path: /tmp/install_k3s.sh
+        state: absent


### PR DESCRIPTION
Issue: #18 

## What?

This PR is regarding issue #18 . I have created the directory `ansible` that will contain everything related to Ansible. The folder structure is inspired from the [officially recommended directory structure](https://docs.ansible.com/ansible/2.8/user_guide/playbooks_best_practices.html#directory-layout). 

This PR specifically address the installation of [`k3s`](https://k3s.io/) using ansible. I have added a separate role for the setup, leaving room for future modifications. 

## Why?

This PR will affect how we install k3s on a freshly installed server or after a system update. This PR affects how we install `k3s`. 

## How?

Wrote separate role `/ansible/roles/k3s/tasks/main.yml` to automate the installation process. It will first check if the binary for `k3s` is present. If not, then it will download the [installation script](https://get.k3s.io), execute the script, check if it's installed and then remove the script from the temp folder.

## Testing?

For now, we have manual testing. We can execute the following to check if this will work or not.

```shell
cd ansible
ansible-playbook playbook.yml -i inventory.yml --ask-become-pass --verbose --check
```

## Screenshots (optional)

![image](https://github.com/user-attachments/assets/fb63bf32-94bb-4f69-aa9b-21b9db8ab5f5)

## Anything Else?

It's my understanding that we will run the ansible playbook directly in the server (by SSHing into it). So, I have only mentioned the host as `localhost` in the `playbook.yml` as well as in the `inventory.yml`. The `ansible.cfg` file is specifically created to ensure that when we run the `ansible-playbook` command, it refers to this specific config file instead of the default one. Read more about the order of preference for the config [here](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#the-configuration-file). It also allow us to specify the `python3` interpreter path. For Ubuntu, the default is `/usr/bin/python3`. 