### PR TITLE
#27 - Add Azure Key Vault resource in Terraform configuration

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -7,13 +7,7 @@ locals {
     admin_username = "kubecraft"
   }
   key_vault = {
-    key_permissions = [
-      "Get"
-    ]
     secret_permissions = [
-      "Get"
-    ]
-    storage_permissions = [
       "Get"
     ]
   }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,13 +2,24 @@ locals {
   vm = {
     name           = "kcVM" # azurerm resource name
     hostname       = "ubuntu-kubecraft"
-    location       = "East US" #"northeurope"
+    location       = "northeurope"
     size           = "Standard_B2ms"
     admin_username = "kubecraft"
   }
   key_vault = {
-    secret_permissions = [
-      "Get"
+    eso_secret_permissions = [
+      "Get",
+      "List"
     ]
+    admin_secret_permissions = [
+      "Get",
+      "List",
+      "Set",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+    # Placeholder for the external secrets operator identifier
+    # eso_object_id = ""
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,8 +2,19 @@ locals {
   vm = {
     name           = "kcVM" # azurerm resource name
     hostname       = "ubuntu-kubecraft"
-    location       = "northeurope"
+    location       = "East US" #"northeurope"
     size           = "Standard_B2ms"
     admin_username = "kubecraft"
+  }
+  key_vault = {
+    key_permissions = [
+      "Get"
+    ]
+    secret_permissions = [
+      "Get"
+    ]
+    storage_permissions = [
+      "Get"
+    ]
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,11 +25,21 @@ resource "azurerm_key_vault" "vault" {
   sku_name                   = "standard"
   soft_delete_retention_days = 7
 
+  # Policies for the external secrets operator
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = var.eso_identity_object_id
+    object_id = data.azurerm_client_config.current.object_id # Remove this line and uncomment the next once ESO id is stored in local
+    #object_id = local.key_vault.eso_object_id
 
-    secret_permissions  = local.key_vault.secret_permissions
+    secret_permissions = local.key_vault.eso_secret_permissions
+  }
+
+  # Policies for the 'control panel' applying our Terraform configs
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = local.key_vault.admin_secret_permissions
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,11 +27,9 @@ resource "azurerm_key_vault" "vault" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
+    object_id = var.eso_identity_object_id
 
-    key_permissions     = local.key_vault.key_permissions
     secret_permissions  = local.key_vault.secret_permissions
-    storage_permissions = local.key_vault.storage_permissions
   }
 }
 

--- a/terraform/ssh.tf
+++ b/terraform/ssh.tf
@@ -1,5 +1,5 @@
 resource "random_pet" "ssh_key_name" {
-  prefix = "ssh"
+  prefix    = "ssh"
   separator = "_"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,0 @@
-variable "eso_identity_object_id" {
-  type        = string
-  description = "Object ID of the Managed Identity used by External Secrets Operator"
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "eso_identity_object_id" {
+  type        = string
+  description = "Object ID of the Managed Identity used by External Secrets Operator"
+}


### PR DESCRIPTION
I've created a minimal key vault resource with a few access policies. One access policy is for the External Secrets Operator (ESO) coming from our cluster, while the other is for the Azure admin to be able to control the contents of the vault.

In order not to break the current configuration, there is a temporary access policy placeholder for the ESO object ID. This placeholder should be deleted and replaced once we are able to obtain an object ID from the ESO. I've left some comments in the configuration for guidance.

I have also added a few locals for easy and accessible management. If this is the wrong way to go about this, please inform me! Criticism is welcome!

**Note**: This pertains to issue [#27](https://github.com/mischavandenburg/kubecraft/issues/27). 
