### PR TITLE
docs: updated my links

### DIFF
--- a/docs/KubeCraft People/index.md
+++ b/docs/KubeCraft People/index.md
@@ -15,7 +15,7 @@ We are incredibly proud of our dedicated community members who contribute their 
 
 [Alfonso Fortunato](https://alfonsofortunato.com) [:simple-github:](https://github.com/MovieMaker93) [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/alfonso-fortunato-a37056b9/)
 
-[James Barrow](https://jamiebarrow.dev/)
+[James Barrow](https://jamiebarrow.dev/) [:simple-github:](https://github.com/jamiebarrow) [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/jamesbarrow1984)
 
 [Jan Charamza](https://charamza.substack.com/)
 


### PR DESCRIPTION
I was browsing the docs site and noticed the [KubeCraft People page](https://docs.kubecraft.community/KubeCraft%20People/) now has links to Github and LinkedIn, so added my details there. 