### PR TITLE
Implement ArgoCD GitOps Structure with CloudNative PostgreSQL

### DIFF
--- a/argocd/apps/nginx/base/deployment.yaml
+++ b/argocd/apps/nginx/base/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80

--- a/argocd/apps/nginx/base/kustomization.yaml
+++ b/argocd/apps/nginx/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+
+namespace: nginx

--- a/argocd/apps/nginx/base/service.yaml
+++ b/argocd/apps/nginx/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx
+  labels:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP

--- a/argocd/apps/nginx/envs/production/kustomization.yaml
+++ b/argocd/apps/nginx/envs/production/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+
+namespace: nginx-production

--- a/argocd/apps/nginx/envs/qa/kustomization.yaml
+++ b/argocd/apps/nginx/envs/qa/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+
+namespace: nginx-qa

--- a/argocd/apps/nginx/envs/staging/kustomization.yaml
+++ b/argocd/apps/nginx/envs/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+
+namespace: nginx-staging

--- a/argocd/appsets/kustomization.yaml
+++ b/argocd/appsets/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # - qa-appset.yaml
+  # - staging-appset.yaml
+  # - production.yaml
+  - qa-apps-appset.yaml
+  - qa-cnpg-appset.yaml
+  - qa-databases-appset.yaml

--- a/argocd/appsets/qa-apps-appset.yaml
+++ b/argocd/appsets/qa-apps-appset.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: qa-apps-appset
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        revision: HEAD
+        directories:
+          - path: argocd/apps/*/envs/qa
+  template:
+    metadata:
+      name: "{{index .path.segments 2}}-qa"
+      annotations:
+        argocd.argoproj.io/sync-wave: "5"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{index .path.segments 2}}-qa"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/argocd/appsets/qa-appset.yaml
+++ b/argocd/appsets/qa-appset.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-qa-appset
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        revision: HEAD
+        directories:
+          - path: argocd/apps/*/envs/qa
+          - path: argocd/infrastructure/cnpg/envs/qa
+          - path: argocd/infrastructure/databases/*/envs/qa
+  template:
+    metadata:
+      name: '{{ if eq (index .path.segments 1) "infrastructure" }}{{ if eq (index .path.segments 2) "cnpg" }}cnpg-qa{{ else if eq (index .path.segments 2) "databases" }}{{ index .path.segments 3 }}-qa{{ end }}{{ else }}{{ index .path.segments 2 }}-qa{{ end }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{ if eq (index .path.segments 1) "infrastructure" }}{{ if eq (index .path.segments 2) "cnpg" }}-5{{ else if eq (index .path.segments 2) "databases" }}0{{ end }}{{ else }}5{{ end }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        targetRevision: HEAD
+        path: "{{ .path.path }}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{ if eq (index .path.segments 1) "infrastructure" }}{{ if eq (index .path.segments 2) "cnpg" }}cnpg-system{{ else if eq (index .path.segments 2) "databases" }}default{{ end }}{{ else }}{{ index .path.segments 2 }}-qa{{ end }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/argocd/appsets/qa-cnpg-appset.yaml
+++ b/argocd/appsets/qa-cnpg-appset.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: qa-cnpg-appset
+  namespace: argocd
+spec:
+  goTemplate: true # Add this to enable template processing
+  goTemplateOptions: ["missingkey=error"] # Add this for error handling
+  generators:
+    - git:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        revision: HEAD
+        directories:
+          - path: argocd/infrastructure/cnpg/envs/qa
+  template:
+    metadata:
+      name: "cnpg-qa"
+      annotations:
+        argocd.argoproj.io/sync-wave: "-5"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        targetRevision: HEAD
+        path: "{{ .path.path }}" # Add spaces for proper Go template syntax
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "cnpg-system"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/argocd/appsets/qa-databases-appset.yaml
+++ b/argocd/appsets/qa-databases-appset.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: qa-databases-appset
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        revision: HEAD
+        directories:
+          - path: argocd/infrastructure/databases/*/envs/qa
+  template:
+    metadata:
+      name: "{{index .path.segments 3}}-qa"
+      annotations:
+        argocd.argoproj.io/sync-wave: "0"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/Tim275/kubecraft.git
+        targetRevision: HEAD
+        path: "{{.path.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "default"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/argocd/infrastructure/cnpg/base/cnpg-grafana.yaml
+++ b/argocd/infrastructure/cnpg/base/cnpg-grafana.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg-grafana-dashboards
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    chart: cloudnative-pg-dashboards
+    repoURL: https://cloudnative-pg.github.io/grafana-dashboards
+    targetRevision: 0.0.3
+    helm:
+      values: |
+        grafana:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/infrastructure/cnpg/base/cnpg.yaml
+++ b/argocd/infrastructure/cnpg/base/cnpg.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnpg-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1" # Install this before regular apps
+spec:
+  project: default
+  source:
+    chart: cloudnative-pg
+    repoURL: https://cloudnative-pg.github.io/charts
+    targetRevision: 0.23.0
+    helm:
+      values: |
+        replicaCount: 1
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true # This flag handles large CRDs correctly

--- a/argocd/infrastructure/cnpg/base/kustomization.yaml
+++ b/argocd/infrastructure/cnpg/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - cnpg.yaml
+  #- cnpg-grafana.yaml
+  # - cluster.yaml

--- a/argocd/infrastructure/cnpg/base/namespace.yaml
+++ b/argocd/infrastructure/cnpg/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-system

--- a/argocd/infrastructure/cnpg/envs/prod/kustomization.yaml
+++ b/argocd/infrastructure/cnpg/envs/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/infrastructure/cnpg/envs/qa/kustomization.yaml
+++ b/argocd/infrastructure/cnpg/envs/qa/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/infrastructure/cnpg/envs/staging/kustomization.yaml
+++ b/argocd/infrastructure/cnpg/envs/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/infrastructure/databases/kubecraft-db/base/cluster.yaml
+++ b/argocd/infrastructure/databases/kubecraft-db/base/cluster.yaml
@@ -1,0 +1,21 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: kubecraft-database-cluster
+  namespace: default # Explicitly setting namespace
+spec:
+  description: Postgres database cluster for kubecraft
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-30-bookworm
+  instances: 3
+
+  inheritedMetadata:
+    labels:
+      app: kubecraft-database
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  storage:
+    size: 1Gi

--- a/argocd/infrastructure/databases/kubecraft-db/base/kustomization.yaml
+++ b/argocd/infrastructure/databases/kubecraft-db/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster.yaml
+
+# Optional: set namespace if desired
+namespace: default

--- a/argocd/infrastructure/databases/kubecraft-db/envs/production/kustomization.yaml
+++ b/argocd/infrastructure/databases/kubecraft-db/envs/production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/infrastructure/databases/kubecraft-db/envs/qa/kustomization.yaml
+++ b/argocd/infrastructure/databases/kubecraft-db/envs/qa/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/infrastructure/databases/kubecraft-db/envs/staging/kustomization.yaml
+++ b/argocd/infrastructure/databases/kubecraft-db/envs/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/argocd/root-app.yaml
+++ b/argocd/root-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root-argocd-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Tim275/kubecraft.git
+    targetRevision: HEAD
+    path: argocd/appsets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
What?

This PR implements a  GitOps workflow using ArgoCD following the pattern from the [many-appsets-demo](https://github.com/kostis-codefresh/many-appsets-demo) and the includet arcticle.

**Three-tier architecture:**

- Kubernetes manifests (Category 1): Apps and infrastructure resources
- ArgoCD ApplicationSets (Category 2): Environment-specific generators
- Root application (Category 3): Single entry point for bootstrapping

**Separated ApplicationSets for each component type rather than one complex ApplicationSet:**

**Seperated Application Sets** for each component type rather than one complex ApplicationSet:

- qa-appset.yaml: Handles application deployments
- qa-cnpg-appset.yaml: Deploys CloudNative PostgreSQL operator
- qa-database-appset.yaml: Manages database clusters

Directory structure:

```
kubecraft/
└── argocd/
    ├── apps/                     # Application manifests (just for testing out)
    │   └── nginx/                # example application
    │       ├── base/
    │       │   ├── deployment.yaml
    │       │   ├── kustomization.yaml
    │       │   └── service.yaml
    │       └── envs/
    │           ├── production/
    │           │   └── kustomization.yaml
    │           ├── qa/
    │           │   └── kustomization.yaml
    │           └── staging/
    │               └── kustomization.yaml
    ├── infrastructure/           # Infrastructure components
    │   ├── cnpg/                 # CloudNative PostgreSQL operator
    │   │   ├── base/
    │   │   │   ├── cnpg-grafana.yaml
    │   │   │   ├── cnpg.yaml
    │   │   │   ├── kustomization.yaml
    │   │   │   └── namespace.yaml
    │   │   └── envs/
    │   │       ├── prod/
    │   │       │   └── kustomization.yaml
    │   │       ├── qa/
    │   │       │   └── kustomization.yaml
    │   │       └── staging/
    │   │           └── kustomization.yaml
    │   └── databases/            # PostgreSQL clusters
    │       └── kubecraft-db/
    │           ├── base/
    │           │   ├── cluster.yaml
    │           │   └── kustomization.yaml
    │           └── envs/
    │               ├── production/
    │               │   └── kustomization.yaml
    │               ├── qa/
    │               │   └── kustomization.yaml
    │               └── staging/
    │                   └── kustomization.yaml
    ├── appsets/                  # ApplicationSets (separated by type)
    │   ├── kustomization.yaml
    │   ├── qa-apps-appset.yaml
    │   ├── qa-appset.yaml
    │   ├── qa-cnpg-appset.yaml
    │   └── qa-databases-appset.yaml
    └── root-app.yaml            # Root application

```
**Why?**

- **Clean separation of concerns**: Kubernetes manifests are completely separated from ArgoCD configuration

- **Simplified development workflow:** Developers can work with standard Kubernetes tools

- **Automatic discovery:** ApplicationSets automatically detect and deploy applications with appropriate overlays

- **Better organization with separate ApplicationSets:** Using multiple dedicated ApplicationSets instead of one complex one provides clearer organization and prevents changes to one component from affecting others

**How?** 

The implementation uses multiple ArgoCD ApplicationSets to organize and deploy different resource types:

1. Infrastructure components are deployed first (sync wave -5)
2. Database clusters are deployed next (sync wave 0)
3. Applications are deployed last (sync wave 5)


Each applicationset uses path-based detection to find and deploy resources with the appropriate environment overlay.
The CloudNative PostgreSQL operator is deployed to the cnpg-system namespace, while database clusters go to the default namespace.

**Testing**

1. Apply the root application to bootstrap everything
`kubectl apply -f kubecraft/argocd/root-app.yaml`

2. Sync the application
`argocd app sync root-argocd-app --grpc-web`

The Outcome should look like that:

![image](https://github.com/user-attachments/assets/73e5c4a0-af9a-4ea6-a69d-bbbf1dcbedaf)

