### PR TITLE
Feat: GHA workflow to create PR with updates to documentation

### DIFF
--- a/.github/workflows/docs/gha.sh
+++ b/.github/workflows/docs/gha.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mapfile -t gldt < <(git log --format='%cs' --grep=^docs -i | uniq)
+GHA_FP=.github/workflows/docs/preamble
+TMP_FP=/tmp/Changelog.md
+cat $GHA_FP > $TMP_FP
+for dt in "${gldt[@]}"; do
+  echo "## $dt" >> $TMP_FP
+  docs=$(git log --format='- %s by %an (%h)' --date=short --grep=^docs --since="${dt} 00:00:00" --until="${dt} 23:59:59")
+  echo -e "$docs" >> $TMP_FP; 
+done

--- a/.github/workflows/docs/preamble
+++ b/.github/workflows/docs/preamble
@@ -1,0 +1,9 @@
+---
+title: Updates
+hide:
+  - toc
+---
+
+Below is a running list of commits with changes to the project documentation. GitHub Actions repopulates this list on every commit to `main`. All documentation-related commits should start with `docs` to be included in the updates.
+
+---

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -3,7 +3,7 @@ name: GHA Docs
 on:
   push:
     branches:
-      - main
+      - test
 
 jobs:
   update-changelog:

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -19,5 +19,8 @@ jobs:
       id: docs_commits
       run: |
         logs=$(git log origin/main..HEAD --format='- %s by %an on %ci (%h)' --grep='^docs')
-        echo "$logs"
-        exit 0
+        if [ -n "$logs" ]; then
+          { head -n 5 Changelog.md; echo -e "\n## $(date +'%Y-%m-%d')\n$logs\n"; tail -n +6 Changelog.md; } > Changelog.md
+          cat Changelog.md
+        fi
+        

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -3,7 +3,7 @@ name: GHA Docs
 on:
   push:
     branches:
-      - test
+      - main
 
 jobs:
   update-changelog:

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Get docs commits
       id: docs_commits
       run: |
-        logs=$(git log origin/main..HEAD --format='- %s (%an, %ad)' --date=short --grep='^docs')
+        logs=$(git log origin/main..HEAD --format='- %s by %an on %ci (%h)' --grep='^docs')
         echo "$logs"
         exit 0

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -1,0 +1,23 @@
+name: GHA Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get docs commits
+      id: docs_commits
+      run: |
+        logs=$(git log origin/main..HEAD --format='- %s (%an, %ad)' --date=short --grep='^docs')
+        echo "$logs"
+        exit 0

--- a/.github/workflows/gha-docs.yml
+++ b/.github/workflows/gha-docs.yml
@@ -17,10 +17,41 @@ jobs:
 
     - name: Get docs commits
       id: docs_commits
+      env:
+        SCRIPT: '.github/workflows/docs/gha.sh'
+        TMP_FP: '/tmp/Changelog.md'
+        FP: 'docs/Updates/Changelog.md'
       run: |
-        logs=$(git log origin/main..HEAD --format='- %s by %an on %ci (%h)' --grep='^docs')
-        if [ -n "$logs" ]; then
-          { head -n 5 Changelog.md; echo -e "\n## $(date +'%Y-%m-%d')\n$logs\n"; tail -n +6 Changelog.md; } > Changelog.md
-          cat Changelog.md
+        ./$SCRIPT
+        if [ -z $FP ]; then
+          touch $FP
         fi
-        
+        if ! diff $TMP_FP $FP &>/dev/null; then
+          mv $TMP_FP $FP
+          echo "NEW_CL=true" >> $GITHUB_ENV
+        fi
+    
+    - name: New branch
+      id: create_branch
+      if: env.NEW_CL == 'true'
+      env:
+        FP: 'docs/Updates/Changelog.md'
+      run: |
+        BRANCH_NAME="docs-changelog-$(date +'%Y%m%d-%H%M%S')"
+        git checkout -b $BRANCH_NAME
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions@github.com"
+        git add $FP
+        git commit -m "chore: Update docs Changelog.md"
+        git push origin $BRANCH_NAME
+        echo "BN=$BRANCH_NAME" >> $GITHUB_ENV
+    
+    - name: Create Pull Request
+      if: env.NEW_CL == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh pr create --title "Update Changelog" \
+          --body "This PR updates the Changelog.md file with the latest documentation changes from $(date +'%Y%m%d-%H%M%S')." \
+          --base main --head ${{ env.BN }} \
+          --label "documentation"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ terraform/terraform.tfstate
 
 # Editor
 .vscode/
+
+# Bak
+*.bak
+*~

--- a/docs/Changes/Changelog.md
+++ b/docs/Changes/Changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changes
+hide:
+  - toc
+---

--- a/docs/Changes/Changelog.md
+++ b/docs/Changes/Changelog.md
@@ -1,5 +1,0 @@
----
-title: Changes
-hide:
-  - toc
----

--- a/docs/KubeCraft People/index.md
+++ b/docs/KubeCraft People/index.md
@@ -17,6 +17,8 @@ We are incredibly proud of our dedicated community members who contribute their 
 
 [James Barrow](https://jamiebarrow.dev/) [:simple-github:](https://github.com/jamiebarrow) [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/jamesbarrow1984)
 
+[James Lazo (jazo)](https://www.jameslazo.com/) [:simple-github:](https://github.com/jameslazo) [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/jameslazo)
+
 [Jan Charamza](https://charamza.substack.com/)
 
 [Jayanath Amaranayake](https://fewmorewords.com) [:simple-github:](https://github.com/jayanath) [:fontawesome-brands-linkedin:](https://www.linkedin.com/in/jayanath/)

--- a/docs/Updates/Changelog.md
+++ b/docs/Updates/Changelog.md
@@ -8,13 +8,8 @@ Below is a running list of commits with changes to the project documentation. Gi
 
 ---
 ## 2025-04-01
-- docs: file structure by jazo (c7aadd7)
-## 2025-03-31
-- docs: test d by jazo (f5d090c)
-- docs: changelog.md test by jazo (d82b743)
-- docs: test c by jazo (6ee0db2)
-- docs: test b by jazo (6ee33bb)
-- docs: test a by jazo (15c74bf)
+- docs: GHA docs bot now live on main by jazo (17235e3)
+- docs: added to authors and people by jazo (5f95010)
 ## 2025-02-13
 - Merge pull request #49 from jamiebarrow/docs/add-github-and-linkedin by Mischa (9d08629)
 ## 2025-02-12

--- a/docs/Updates/Changelog.md
+++ b/docs/Updates/Changelog.md
@@ -1,0 +1,38 @@
+---
+title: Updates
+hide:
+  - toc
+---
+
+Below is a running list of commits with changes to the project documentation. GitHub Actions repopulates this list on every commit to `main`. All documentation-related commits should start with `docs` to be included in the updates.
+
+---
+## 2025-04-01
+- docs: file structure by jazo (c7aadd7)
+## 2025-03-31
+- docs: test d by jazo (f5d090c)
+- docs: changelog.md test by jazo (d82b743)
+- docs: test c by jazo (6ee0db2)
+- docs: test b by jazo (6ee33bb)
+- docs: test a by jazo (15c74bf)
+## 2025-02-13
+- Merge pull request #49 from jamiebarrow/docs/add-github-and-linkedin by Mischa (9d08629)
+## 2025-02-12
+- docs: updated my links by James Barrow (b8dfbeb)
+## 2025-01-10
+- Merge pull request #42 from mischavandenburg/docs/update-pipeline-instructions by Mischa (7dfce3a)
+- docs: update pipeline instructions by Mischa van den Burg (736e89c)
+## 2025-01-09
+- docs:added pedro chang by seyza (586831c)
+## 2025-01-01
+- docs: Rearranged markdown files and restructured the folders. Minor tweaks to themes. by hyperoot (2ac25a7)
+- docs: fix: minor theme fix for search box by hyperoot (421f3ef)
+- docs: improved the site and enabled the blogs by hyperoot (2b653a9)
+## 2024-12-31
+- docs: update terraform pipeline docs by Lucioschenkel (361ff9b)
+## 2024-12-29
+- docs: add documentation around terraform pipeline by Lucioschenkel (ab3321c)
+## 2024-12-25
+- docs: include package instructions by Mischa van den Burg (60dcf4d)
+## 2024-08-06
+- docs: Adds docs on getting started with Terraform by Rod Stewart (2945005)

--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -4,3 +4,9 @@ authors:
     description: Contributor
     avatar: https://avatars.githubusercontent.com/u/78068806?v=4
     url: https://github.com/HYP3R00T
+
+  jazo:
+    name: James Lazo
+    description: Contributor
+    avatar: https://avatars.githubusercontent.com/u/131928783?v=4
+    url: https://github.com/jameslazo


### PR DESCRIPTION
## What?

This PR covers [issue 35](https://github.com/mischavandenburg/kubecraft/issues/35) adding a GitHub Actions workflow to catalog all `docs` commits and publishing them to the [Updates](https://docs.kubecraft.community/Updates) page.

## Why?

This feature extends the KubeCraft project's CI/CD to its documentation processes, automating the publication of all `docs` commits moving forward.

## How?

The GHA workflow executes a script and runs steps that perform the following:
- Scans commits for `docs` in the subject
- Formats `docs` commits into a brief description with committer and hash information
- Groups commits by date
- Creates a new list of commits for publication when new `docs` commits are made
- Creates a PR to merge the updated list of commits

## Testing?

:heavy_check_mark: Validated script output compatibility with MkDocs in the repo's dev container
:heavy_check_mark: Used GitHub Local Actions to validate GHA runner parameters
:heavy_check_mark: Confirmed result with commits to fork

## Screenshots (optional)
### Dev Container
![Screenshot from 2025-04-01 15-29-30](https://github.com/user-attachments/assets/1c99fff0-3317-4901-b78b-8840d4e18935)

### GHA Workflow on Fork
![Screenshot from 2025-04-01 15-43-03](https://github.com/user-attachments/assets/d9cb91d3-47e8-4036-8cd7-f7af1c04ad4c)

### Pull Request
![Screenshot from 2025-04-01 16-17-14](https://github.com/user-attachments/assets/d8f73a9c-d4ed-406b-ad06-b3fb0a699d21)

## Anything Else?
### Resources
- [Mastering Git Log Grep](https://gitscripts.com/git-log-grep)
- [Workflow Variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
- [GHA Expressions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions)
